### PR TITLE
Upgrade of Zeppelin version and added persistent storage

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -214,7 +214,7 @@ echo
 oc import-image -n ${IOT_OSE_PROJECT} jboss-decisionserver63-openshift --all=true
 oc import-image -n ${IOT_OSE_PROJECT} jboss-amq-62 --all=true
 oc import-image -n ${IOT_OSE_PROJECT} fis-karaf-openshift --all=true
-oc import-image -n ${IOT_OSE_PROJECT} rhel --all=true
+oc import-image -n ${IOT_OSE_PROJECT} rhel7 --all=true
 
 echo
 echo "Deploying PostgreSQL..."
@@ -291,7 +291,7 @@ echo
 # Get Route
 ZEPPELIN_ROUTE=$(oc get routes rhel-zeppelin --template='{{ .spec.host }}')
 
-curl -s --fail -H "Content-Type: application/json" -X POST -d "{\"name\":\"iot-ose\",\"group\":\"psql\",\"properties\":{\"postgresql.password\":\"${POSTGRESQL_PASSWORD}\",\"postgresql.max.result\":\"1000\",\"postgresql.user\":\"${POSTGRESQL_USERNAME}\",\"postgresql.url\":\"jdbc:postgresql://postgresql:5432/\",\"postgresql.driver.name\":\"org.postgresql.Driver\"},\"dependencies\":[],\"option\":{\"remote\":true,\"isExistingProcess\":false,\"perNoteSession\":false,\"perNoteProcess\":false},\"propertyValue\":\"\",\"propertyKey\":\"\"}" http://${ZEPPELIN_ROUTE}/api/interpreter/setting
+curl -s --fail -H "Content-Type: application/json" -X POST -d "{\"name\":\"iot-ose\",\"group\":\"psql\",\"properties\":{\"postgresql.password\":\"${POSTGRESQL_PASSWORD}\",\"postgresql.max.result\":\"1000\",\"postgresql.user\":\"${POSTGRESQL_USERNAME}\",\"postgresql.url\":\"jdbc:postgresql://postgresql:5432/iot\",\"postgresql.driver.name\":\"org.postgresql.Driver\"},\"dependencies\":[],\"option\":{\"remote\":true,\"isExistingProcess\":false,\"perNoteSession\":false,\"perNoteProcess\":false},\"propertyValue\":\"\",\"propertyKey\":\"\"}" http://${ZEPPELIN_ROUTE}/api/interpreter/setting
 
 echo
 echo "OpenShift IoT Demo Setup Complete."

--- a/init.sh
+++ b/init.sh
@@ -282,6 +282,17 @@ oc process -f ${SCRIPT_BASE_DIR}/support/templates/rhel-zeppelin.json | oc creat
 
 validate_build_deploy "rhel-zeppelin"
 
+sleep 10
+
+echo
+echo "Adding IOT Postgresql Interperter"
+echo
+
+# Get Route
+ZEPPELIN_ROUTE=$(oc get routes rhel-zeppelin --template='{{ .spec.host }}')
+
+curl -s --fail -H "Content-Type: application/json" -X POST -d "{\"name\":\"iot-ose\",\"group\":\"psql\",\"properties\":{\"postgresql.password\":\"${POSTGRESQL_PASSWORD}\",\"postgresql.max.result\":\"1000\",\"postgresql.user\":\"${POSTGRESQL_USERNAME}\",\"postgresql.url\":\"jdbc:postgresql://postgresql:5432/\",\"postgresql.driver.name\":\"org.postgresql.Driver\"},\"dependencies\":[],\"option\":{\"remote\":true,\"isExistingProcess\":false,\"perNoteSession\":false,\"perNoteProcess\":false},\"propertyValue\":\"\",\"propertyKey\":\"\"}" http://${ZEPPELIN_ROUTE}/api/interpreter/setting
+
 echo
 echo "OpenShift IoT Demo Setup Complete."
 echo

--- a/rhel-zeppelin/Dockerfile
+++ b/rhel-zeppelin/Dockerfile
@@ -2,28 +2,39 @@ FROM rhel:7.2
 
 MAINTAINER Andrew Block <andy.block@gmail.com>
 
-ENV HOME /opt/zeppelin
-ENV MAVEN_VERSION 3.3.9
-ENV JAVA_HOME /usr/lib/jvm/java
-ENV ZEPPELIN_VERSION 0.6.1
+ENV HOME=/opt/zeppelin \
+    MAVEN_VERSION=3.3.9 \
+    JAVA_HOME=/usr/lib/jvm/java \
+    ZEPPELIN_VERSION=0.6.2 \
+    ZEPPELIN_SERVER_HOME=/opt/zeppelin/server \
+    ZEPPELIN_STORAGE_DIR=/opt/zeppelin/storage \
+    ZEPPELIN_CONF_DIR=/opt/zeppelin/storage/conf \
+    ZEPPELIN_LOG_DIR=/opt/zeppelin/storage/logs \
+    ZEPPELIN_NOTEBOOK_DIR=/opt/zeppelin/storage/notebook \
+    ZEPPELIN_INTERPRETER_DIR=/opt/zeppelin/storage/interpreter
+
 
 RUN yum clean all && \
     export INSTALL_PKGS="java-1.8.0-openjdk-devel java-1.8.0-openjdk-headless gettext tar git which unzip" && \
     yum install -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
-    mkdir -p /opt/zeppelin && \
+    mkdir -p $HOME/server $HOME/bin $HOME/storage && \
     curl -fsSL http://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar xzf - -C /usr/share \
       && mv /usr/share/apache-maven-$MAVEN_VERSION /usr/share/maven \
       && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn && \
-    curl -fsSL http://archive.apache.org/dist/zeppelin/zeppelin-$ZEPPELIN_VERSION/zeppelin-${ZEPPELIN_VERSION}-bin-all.tgz | tar xzf - --strip 1 -C $HOME && \
-    chown -R 1001:0 /opt/zeppelin && \
-    chmod -R "g+rwX" /opt/zeppelin
+    curl -fsSL http://archive.apache.org/dist/zeppelin/zeppelin-$ZEPPELIN_VERSION/zeppelin-${ZEPPELIN_VERSION}-bin-netinst.tgz | tar xzf - --strip 1 -C $ZEPPELIN_SERVER_HOME/ && \
+    chown -R 1001:0 $HOME/server $HOME/bin $HOME/storage && \
+    chmod -R "g+rwX" $HOME/server $HOME/bin $HOME/storage
+    
+ADD bin/start.sh /$HOME/bin/
 
 EXPOSE 8080
 
 WORKDIR /opt/zeppelin
 
+VOLUME /opt/zeppelin/storage
+
 USER 1001
 
-ENTRYPOINT ["/opt/zeppelin/bin/zeppelin.sh"]
+ENTRYPOINT ["/opt/zeppelin/bin/start.sh"]

--- a/rhel-zeppelin/bin/start.sh
+++ b/rhel-zeppelin/bin/start.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+
+# Check if server previously configured
+
+if [ ! -d "$ZEPPELIN_CONF_DIR" ] && [ ! -d "$ZEPPELIN_NOTEBOOK_DIR" ] && [ ! -d "$ZEPPELIN_LOG_DIR" ]  && [ ! -d "$ZEPPELIN_INTERPRETER_DIR" ]; then
+    
+    echo "Storage directories do not exist. Creating..."
+    
+    mkdir -p "${ZEPPELIN_CONF_DIR}" "${ZEPPELIN_NOTEBOOK_DIR}" "${ZEPPELIN_LOG_DIR}" "${ZEPPELIN_INTERPRETER_DIR}"
+    
+    echo "Copying configuration files..."
+    
+    cp ${ZEPPELIN_SERVER_HOME}/conf/* ${ZEPPELIN_CONF_DIR}
+    
+    echo "Copying interpreters..."
+    cp -R ${ZEPPELIN_SERVER_HOME}/interpreter/* ${ZEPPELIN_INTERPRETER_DIR}
+    
+    echo "Installing postgresql interpreter..."
+    
+    # Install Postgresql Interpreter
+    ${ZEPPELIN_SERVER_HOME}/bin/install-interpreter.sh --name postgresql
+    
+fi
+
+# Start Zeppelin Server
+exec ${ZEPPELIN_SERVER_HOME}/bin/zeppelin.sh $@

--- a/support/templates/rhel-zeppelin.json
+++ b/support/templates/rhel-zeppelin.json
@@ -54,6 +54,13 @@
             "from": "[a-zA-Z0-9]{8}",
             "generate": "expression",
             "required": true
+        },
+        {
+            "name": "VOLUME_CAPACITY",
+            "displayName": "Volume Capacity",
+            "description": "Volume space available for data, e.g. 512Mi, 2Gi.",
+            "value": "1Gi",
+            "required": true
         }
     ],
     "objects": [
@@ -105,6 +112,23 @@
                 "name": "${APPLICATION_NAME}",
                 "labels": {
                     "application": "${APPLICATION_NAME}"
+                }
+            }
+        },
+        {
+            "kind": "PersistentVolumeClaim",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${APPLICATION_NAME}"
+            },
+            "spec": {
+                "accessModes": [
+                    "ReadWriteOnce"
+                ],
+                "resources": {
+                    "requests": {
+                        "storage": "${VOLUME_CAPACITY}"
+                    }
                 }
             }
         },
@@ -221,7 +245,21 @@
                                         "containerPort": 8080,
                                         "protocol": "TCP"
                                     }
+                                ],
+                                "volumeMounts": [
+                                    {
+                                        "name": "${APPLICATION_NAME}-storage",
+                                        "mountPath": "/opt/zeppelin/storage"
+                                    }
                                 ]
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "${APPLICATION_NAME}-storage",
+                                "persistentVolumeClaim": {
+                                    "claimName": "${APPLICATION_NAME}"
+                                }
                             }
                         ]
                     }


### PR DESCRIPTION
Upgraded zeppelin container 0.6.2 and added support for persistent storage

`init.sh` script now handles the creation of the _iot-ose_ interpreter. User will still need to import the notebook and bind the interpreter
